### PR TITLE
Add pointer events to 3D object vertices

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Web:
 - [ ] Randomly distribute interactive nodes
   - Maybe only in the head
 - [ ] Implement something like the effect from https://threejs.org/examples/#webgl_video_kinect (Lauro's suggestion)
+- [ ] Create KSM NPM organization
+- [ ] Publish as NPM package
+- [ ] Read brand colors as input (so we can pass it along from `ksm-app`)
 
 3D model:
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Web:
 - [x] Refactor and move three.js experiments to this repos
 - [x] Make it a React component
 - [x] Check with Alan/Lauro what kind of data we get from Kusama
-- [ ] Make 3D Canary nodes interactive
-- [ ] Randomly distribute interactive nodes
+- [x] Make 3D Canary nodes interactive
+- [x] Randomly distribute interactive nodes
   - Maybe only in the head
 - [ ] Implement something like the effect from https://threejs.org/examples/#webgl_video_kinect (Lauro's suggestion)
 - [ ] Create KSM NPM organization
@@ -43,3 +43,4 @@ Web:
 
 - [ ] Clean up mesh vertices on feet
 - [ ] Add more vertices to legs
+- [ ] Test loading static/animated glTF files (glb, binary)

--- a/src/index.js
+++ b/src/index.js
@@ -4,19 +4,70 @@ import ThreeCanary from "./lib/ThreeCanary";
 
 import "./styles.css";
 
-function App() {
-  return (
-    <div
+// Utils
+
+const choose = (choices) => {
+  let index = Math.floor(Math.random() * choices.length);
+  return choices[index];
+}
+
+const nodesDataFactory = (n) => {
+  let data = [];
+  for (let i=0; i<n; i+=1) {
+    data.push({
+      "id": Math.floor(Math.random()*100),
+      "name": choose(["Arthur C. Clarke", "Douglas Adams", "Isaac Asimov"]),
+      "color": choose(["#0000ff", "#ff0000"])
+    })
+  }
+  return data;
+}
+
+// Example hosting component
+
+class App extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      nodesData: nodesDataFactory(50),
+      nodeSelected: null
+    };
+  }
+
+  onNodeSelected(node) {
+    this.setState({nodeSelected: node});
+    console.log("Node Selected:", this.state.nodeSelected);
+  }
+
+  render() {
+
+    return (
+      <div
       className="App"
       style={{
         display: "flex",
         flexDirection: "column",
         alignItems: "center"
       }}
-    >
-      <ThreeCanary objectUrl={"/assets/canary.obj"} />
-    </div>
-  );
+      >
+        <ThreeCanary
+          objectUrl={"/assets/canary.obj"}
+          nodes={this.state.nodesData}
+          onNodeSelected={this.onNodeSelected.bind(this)}
+        />
+        <div
+          className="Info"
+          style={{
+            padding: 10,
+            color: this.state.nodeSelected ? this.state.nodeSelected.color: "#ffffff"
+          }}
+        >
+          {this.state.nodeSelected ? this.state.nodeSelected.name: ""}
+        </div>
+      </div>
+    );
+  }
+  
 }
 
 const rootElement = document.getElementById("root");

--- a/src/lib/ThreeCanary.js
+++ b/src/lib/ThreeCanary.js
@@ -1,7 +1,8 @@
 import React, { Component } from "react";
 import * as THREE from "three";
+import { Vector3 } from "three";
 import { OBJLoader } from "three-obj-mtl-loader";
-// import OrbitControls from "three-orbitcontrols";
+import OrbitControls from "three-orbitcontrols";
 
 class ThreeCanary extends Component {
   constructor(props) {
@@ -17,14 +18,6 @@ class ThreeCanary extends Component {
     this.addLights();
     this.addMaterials();
     this.addModels();
-
-    // Add a cube to visualize intersection with pointer
-    const geometry = new THREE.BoxGeometry();
-    const material = new THREE.MeshBasicMaterial( { color: 0xffffff } );
-    const cube = new THREE.Mesh( geometry, material );
-    this.cube = cube;
-    this.cube.scale.set(0.05, 0.05, 0.05);
-    this.scene.add( cube );
 
     this.renderScene();
     this.start();
@@ -47,18 +40,25 @@ class ThreeCanary extends Component {
 
   addCamera() {
     this.camera = new THREE.PerspectiveCamera(40, this.width / this.height, 1, 3000);
-    this.camera.position.z = 6;
-    this.camera.position.y = 2;
-    this.camera.position.x = -3;
+    this.camera.position.z = 30;
+    this.camera.position.y = 5;
   }
 
   addControls() {
-    // this.controls = new OrbitControls(this.camera, this.renderer.domElement);
+    this.controls = new OrbitControls(this.camera, this.renderer.domElement);
     // Raycaster from camera to vertex pointer so we can interactive with 3D vertices
     this.pointer = new THREE.Vector2();
     this.raycaster = new THREE.Raycaster();
-    this.raycaster.params.Points.threshold = 0.05;
-    this.intersected = null;
+    // this.raycaster.params.Points.threshold = 2;
+    this.hoveredNodes = [];
+
+    // Add a cube to visualize intersection with pointer
+    // const geometry = new THREE.BoxGeometry();
+    // const material = new THREE.MeshBasicMaterial( { color: 0xffffff } );
+    // const cube = new THREE.Mesh( geometry, material );
+    // this.cube = cube;
+    // this.cube.scale.set(0.05, 0.05, 0.05);
+    // this.scene.add( cube );
 
     // window.addEventListener("resize", this.onWindowResize);
     document.addEventListener("pointermove", this.onPointerMove);
@@ -69,9 +69,9 @@ class ThreeCanary extends Component {
     lights[0] = new THREE.PointLight(0xff00ff, 1, 0);
     lights[1] = new THREE.PointLight(0xffffff, 1, 0);
     lights[2] = new THREE.PointLight(0xffffff, 1, 0);
-    lights[0].position.set(0, 200, 0);
-    lights[1].position.set(100, 200, 100);
-    lights[2].position.set(-100, -200, -100);
+    lights[0].position.set(0, 0, 0);
+    lights[1].position.set(0, 0, 0);
+    lights[2].position.set(0, 0, 0);
     this.scene.add(lights[0]);
     this.scene.add(lights[1]);
     this.scene.add(lights[2]);
@@ -80,10 +80,10 @@ class ThreeCanary extends Component {
   addMaterials() {
     // TODO: Move to brand color pallet
     this.canaryMtlMesh =  new THREE.PointsMaterial( { color: 0xe6007a });
-    this.canaryMtlPoints = new THREE.PointsMaterial( {
-      color: 0x8200f9,
-      size: 0.1
-    } );
+    // this.canaryMtlPoints = new THREE.PointsMaterial( {
+    //   color: 0x8200f9,
+    //   size: 0.1
+    // } );
   }
 
   addModels() {
@@ -108,13 +108,34 @@ class ThreeCanary extends Component {
 
             // Create point clouds based on mesh
             var childGeometry = child.geometry.clone();
-            this.canaryPointCloud = new THREE.Points(childGeometry, this.canaryMtlPoints);
-            this.canaryPointCloud.position.setY(-2);
-            this.canaryPointCloud.rotation.y = Math.PI/4;
-            this.canaryPointCloud.scale.set(4, 4, 4);
-            this.scene.add(this.canaryPointCloud);
+            // this.canaryPointCloud = new THREE.Points(childGeometry, this.canaryMtlPoints);
+            // this.canaryPointCloud.position.setY(-2);
+            // this.canaryPointCloud.rotation.y = Math.PI/4;
+            // this.canaryPointCloud.scale.set(4, 4, 4);
+            // this.scene.add(this.canaryPointCloud);
+            // let pos = this.canaryPointCloud.geometry.attributes.position;
 
-            console.log("Creating point cloud", this.canaryPointCloud);
+            // Create a group of meshes as a point cloud instead of points, to have
+            // per-mesh control
+            let pos = childGeometry.attributes.position;
+            this.canaryPointCloudGroup = new THREE.Group();
+            for (let i=0; i<pos.count; i+=1) {
+
+              let geometry = new THREE.BoxGeometry();
+              let material = new THREE.MeshBasicMaterial( { color: 0x0000ff } );
+              material.wireframe = false;
+              material.needsUpdate = true;
+              let cube = new THREE.Mesh( geometry, material );
+
+              cube.position.copy(new Vector3(pos.getX(i), pos.getY(i), pos.getZ(i)));
+              let _scale = Math.random()*100;
+              cube.scale.set(_scale, _scale, _scale);
+              this.canaryPointCloudGroup.add( cube );
+            }
+            this.canaryPointCloudGroup.position.setY(-2);
+            this.canaryPointCloudGroup.rotation.y = Math.PI/4;
+            this.canaryPointCloudGroup.scale.set(4, 4, 4);
+            this.scene.add( this.canaryPointCloudGroup );
           }
         })
 
@@ -164,16 +185,33 @@ class ThreeCanary extends Component {
     
     this.raycaster.setFromCamera(this.pointer, this.camera);
 
-    if (this.canaryPointCloud) {
-      const intersects = this.raycaster.intersectObject(this.canaryPointCloud);
-      let intersection = ( intersects.length ) > 0 ? intersects[0] : null;
-      if (intersection !== null) {
-        console.log("intersection", intersection);
-        // intersection.object.material.color.set( 0xff0000 );
-        this.cube.position.copy(intersection.point);
-        // intersection.object.point.x;
+    this.hoveredNodes = [];
+    if (this.canaryPointCloudGroup) {
+      const intersects = this.raycaster.intersectObject(this.canaryPointCloudGroup, true);
+      if (intersects != null && intersects.length > 0) {
+        for (let i=0; i<intersects.length; i+=1) {
+          if (!this.hoveredNodes.includes(intersects[i].object.id))
+            this.hoveredNodes.push(intersects[i].object.id);
+        }
       }
 
+      for (let i=0; i<this.canaryPointCloudGroup.children.length; i+=1) {
+
+        if (this.hoveredNodes.includes(this.canaryPointCloudGroup.children[i].id)) {
+          this.canaryPointCloudGroup.children[i].material.color.set( 0xffffff );
+          this.canaryPointCloudGroup.children[i].material.wireframe = true;
+          this.canaryPointCloudGroup.children[i].scale.set(0.15, 0.15, 0.15);
+          this.canaryPointCloudGroup.children[i].rotateX(Math.sin(this.frameId / 70)/20);
+          this.canaryPointCloudGroup.children[i].rotateY(Math.sin(this.frameId / 100)/20);
+          this.canaryPointCloudGroup.children[i].rotateZ(Math.sin(this.frameId / 80)/20);
+      
+        } else {
+          this.canaryPointCloudGroup.children[i].material.color.set( 0x0000ff );
+          this.canaryPointCloudGroup.children[i].material.wireframe = false;
+          this.canaryPointCloudGroup.children[i].scale.set(0.05, 0.05, 0.05);
+        }
+        // this.canaryPointCloudGroup.children[i].position.y += Math.sin(this.frameId / 50) / 1000;
+      }
     }
 
     this.renderScene();

--- a/src/styles.css
+++ b/src/styles.css
@@ -7,3 +7,7 @@
 body {
   background: #000;
 }
+
+canvas {
+  border: 1px solid #333;
+}


### PR DESCRIPTION
We moved from only a static 3D object being rendered to an interactive mesh of nodes. Now, users can interact with nodes with pointer (mouse) events. For now, hover styling and click/un-click are implemented.

We extended the `ThreeCanary` component API:
- `onNodeSelected` is exposed as a callback, called when a node is selected. The selected `node` is returned as payload
- `nodes` can be given to the component, as a object with any kind of values (however, if `color` is given, the node is colored with  the respective color). For now, `nodes` are distributed randomly along the 3D object surface (vertices).

The example hosting component (`src/index.js`) was also updated, please refer to it to understand how to use the `ThreeCanary` component, which now looks like this:

```js
<ThreeCanary
          objectUrl={"/assets/canary.obj"}
          nodes=// ... node data ...
          onNodeSelected=//... a callback to be called when a node is selected ...
/>
```

The final result looks like the following:

https://user-images.githubusercontent.com/49062/128619217-5e95c445-e011-4592-91e7-ba6c386c3f90.mp4
