### PR TITLE
Add onNodeClick handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2361,11 +2361,346 @@
       "dev": true,
       "optional": true
     },
+    "@noble/hashes": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-0.4.5.tgz",
+      "integrity": "sha512-oK/2b9gHb1CfiFwpPHQs010WgROn4ioilT7TFwxMVwuDaXEJP3QPhyedYbOpgM4JDBgT9n5gaispBQlkaAgT6g=="
+    },
+    "@noble/secp256k1": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.3.4.tgz",
+      "integrity": "sha512-ZVRouDO5mbdCiDg4zCd3ZZABduRtpy4tCnB33Gh9upHe9tRzpiqbRSN1VTjrj/2g8u2c6MBi0YLNnNQpBYOiWg=="
+    },
     "@nodelib/fs.stat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
+    },
+    "@polkadot/keyring": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-8.2.2.tgz",
+      "integrity": "sha512-GK8puQVtQJ67sVyq0WIWHPeRXfIcqz2ztgRHnGP4JEptS9NSFByQNq1EEpQnEUZwXu9CQfHz90eiLZc1BpC8lQ==",
+      "requires": {
+        "@babel/runtime": "^7.16.5",
+        "@polkadot/util": "8.2.2",
+        "@polkadot/util-crypto": "8.2.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+          "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@polkadot/networks": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-8.2.2.tgz",
+      "integrity": "sha512-PshHrf5wBXib63l03YISnHMf5/fS1/Jv2rEN58EgYy9VK87HBXjT7qQ1Ea/d1cFI2EmfEDvhFsP+u3i6AlejQQ==",
+      "requires": {
+        "@babel/runtime": "^7.16.5"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+          "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@polkadot/react-identicon": {
+      "version": "0.87.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/react-identicon/-/react-identicon-0.87.6.tgz",
+      "integrity": "sha512-d7/DZHBYaeCliKzO0n6zyO7vhzBcQEqv1RS3vKLEn81U0t0eMtHqRhyyiKK/dy3Yd1cY+h5K/0J+VeXI6XBtuA==",
+      "requires": {
+        "@babel/runtime": "^7.16.5",
+        "@polkadot/keyring": "^8.2.2",
+        "@polkadot/ui-settings": "0.87.6",
+        "@polkadot/ui-shared": "0.87.6",
+        "@polkadot/util": "^8.2.2",
+        "@polkadot/util-crypto": "^8.2.2",
+        "color": "^3.2.1",
+        "ethereum-blockies-base64": "^1.0.2",
+        "jdenticon": "3.1.1",
+        "react-copy-to-clipboard": "^5.0.4",
+        "styled-components": "^5.3.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+          "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@polkadot/ui-settings": {
+      "version": "0.87.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/ui-settings/-/ui-settings-0.87.6.tgz",
+      "integrity": "sha512-aSXhdNtBI2Jf+JJKnhRUFmsfEqSH3mho0kWqIK75VnMhLEIoywbcfYy/U6uw6PxOhFVKghMgNCA5tpZKJztVkg==",
+      "requires": {
+        "@babel/runtime": "^7.16.5",
+        "@polkadot/networks": "^8.2.2",
+        "@polkadot/util": "^8.2.2",
+        "eventemitter3": "^4.0.7",
+        "store": "^2.0.12"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+          "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@polkadot/ui-shared": {
+      "version": "0.87.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/ui-shared/-/ui-shared-0.87.6.tgz",
+      "integrity": "sha512-LxYXK9xAa1MTL4RxryC4f0T27yfz24FT2Ist6eYG+cTq4oKnsmFZATh4kwKVRH1nESz7aXUtM8ks6M10dPcasw==",
+      "requires": {
+        "@babel/runtime": "^7.16.5",
+        "color": "^3.2.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+          "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@polkadot/util": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-8.2.2.tgz",
+      "integrity": "sha512-tiHe0rcQvofd3vUVCRmvfULAv9yBG7s/huv1ZLVY/JGT1JBDonc1HWU3Vdb5MvWpx2R+HHv19ORHyD/LiROE9A==",
+      "requires": {
+        "@babel/runtime": "^7.16.5",
+        "@polkadot/x-bigint": "8.2.2",
+        "@polkadot/x-global": "8.2.2",
+        "@polkadot/x-textdecoder": "8.2.2",
+        "@polkadot/x-textencoder": "8.2.2",
+        "@types/bn.js": "^4.11.6",
+        "bn.js": "^4.12.0",
+        "ip-regex": "^4.3.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+          "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        },
+        "ip-regex": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+          "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
+        }
+      }
+    },
+    "@polkadot/util-crypto": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-8.2.2.tgz",
+      "integrity": "sha512-bKFE6j1q2Dnz1o1QFvhX2QzkMLi9QHU4a5T7+El5J7OsOxGqssMAVHAmB+YoAuSLqPSQBmZa9CN23IiuJnfsbw==",
+      "requires": {
+        "@babel/runtime": "^7.16.5",
+        "@noble/hashes": "^0.4.5",
+        "@noble/secp256k1": "^1.3.4",
+        "@polkadot/networks": "8.2.2",
+        "@polkadot/util": "8.2.2",
+        "@polkadot/wasm-crypto": "^4.5.1",
+        "@polkadot/x-bigint": "8.2.2",
+        "@polkadot/x-randomvalues": "8.2.2",
+        "ed2curve": "^0.3.0",
+        "micro-base": "^0.10.0",
+        "tweetnacl": "^1.0.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+          "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+        }
+      }
+    },
+    "@polkadot/wasm-crypto": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-4.5.1.tgz",
+      "integrity": "sha512-Cr21ais3Kq3aedIHZ3J1tjgeD/+K8FCiwEawr0oRywNBSJR8wyuZMePs4swR/6xm8wbBkpqoBVHz/UQHqqQJmA==",
+      "requires": {
+        "@babel/runtime": "^7.16.3",
+        "@polkadot/wasm-crypto-asmjs": "^4.5.1",
+        "@polkadot/wasm-crypto-wasm": "^4.5.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+          "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@polkadot/wasm-crypto-asmjs": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-4.5.1.tgz",
+      "integrity": "sha512-DOdRiWhxVvmqTvp+E9z1j+Yr0zDOGsDvqnT/eNw0Dl1FVUOImsEa7FKns/urASmcxCVEE1jtUWSnij29jrORMQ==",
+      "requires": {
+        "@babel/runtime": "^7.16.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+          "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@polkadot/wasm-crypto-wasm": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-4.5.1.tgz",
+      "integrity": "sha512-hPwke85HxpgG/RAlwdCE8u5w7bThvWg399mlB+XjogXMxOUWBZSgq2XYbgzROUXx27inK9nStF4Pnc4zJnqs9A==",
+      "requires": {
+        "@babel/runtime": "^7.16.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+          "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@polkadot/x-bigint": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-8.2.2.tgz",
+      "integrity": "sha512-fX3o3FhfQNxdpA5PV4L9PrjjSKG2ZmfFOfv3TrKwsDNtZMktDDcpmW3up53LJ53FszB/WHH6WwKsehmcqAYDIw==",
+      "requires": {
+        "@babel/runtime": "^7.16.5",
+        "@polkadot/x-global": "8.2.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+          "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@polkadot/x-global": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-8.2.2.tgz",
+      "integrity": "sha512-eTJ6edgoIKzjfdYN3Y6ZuJUGRAAc8Uc5X8r4/1QmhOy427QbfRKRL/cbcLat1XbyM52aplOvZf31KXTAkMREdQ==",
+      "requires": {
+        "@babel/runtime": "^7.16.5"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+          "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@polkadot/x-randomvalues": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-8.2.2.tgz",
+      "integrity": "sha512-v3dx0xvWHd5t6e41Fte63WFX/t1Fu9ug3tOr/QE6yMFrDSeDW9TzFJKklakc0tXryqW0cL4qZzUdSvguGC2TPA==",
+      "requires": {
+        "@babel/runtime": "^7.16.5",
+        "@polkadot/x-global": "8.2.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+          "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@polkadot/x-textdecoder": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-8.2.2.tgz",
+      "integrity": "sha512-HQ/pSl4FREnxK0V7nvEdTwI08Erh6KPLwHZ0rSfUJKVDZ+NwfeW4BW/8xCEJOQIRB948Dqerl0XjEn4xCA+OPg==",
+      "requires": {
+        "@babel/runtime": "^7.16.5",
+        "@polkadot/x-global": "8.2.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+          "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@polkadot/x-textencoder": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-8.2.2.tgz",
+      "integrity": "sha512-ZAOwYi/y1wRYb3WoWZMDfYPrmbPSasog2uknt8p9u2WELrrfj4zF/fRnSuMjLUNtvJuKSzj4LUCKHwTY+peSrQ==",
+      "requires": {
+        "@babel/runtime": "^7.16.5",
+        "@polkadot/x-global": "8.2.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+          "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
     },
     "@react-three/drei": {
       "version": "7.16.8",
@@ -2468,6 +2803,19 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
+    },
+    "@types/bn.js": {
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.2.tgz",
+      "integrity": "sha512-JepeIUPFDARgIs0zD/SKPgFsJEAF0X5/qO80llx59gOxFTboS9Amv3S+QfB7lqBId5sFXJ99BN0J6zFRvL9dDA=="
     },
     "@types/q": {
       "version": "1.5.5",
@@ -4532,6 +4880,14 @@
       "integrity": "sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA==",
       "dev": true
     },
+    "canvas-renderer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/canvas-renderer/-/canvas-renderer-2.2.0.tgz",
+      "integrity": "sha512-Itdq9pwXcs4IbbkRCXc7reeGBk6i6tlDtZTjE1yc+KvYkx1Mt3WLf6tidZ/Ixbm7Vmi+jpWKG0dRBor67x9yGw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "capture-exit": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
@@ -4964,7 +5320,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
       "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.3",
         "color-string": "^1.6.0"
@@ -4987,7 +5342,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
       "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
-      "dev": true,
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -5159,6 +5513,14 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
+    },
+    "copy-to-clipboard": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
     },
     "core-js": {
       "version": "3.19.0",
@@ -6234,6 +6596,21 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "ed2curve": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.3.0.tgz",
+      "integrity": "sha512-8w2fmmq3hv9rCrcI7g9hms2pMunQr1JINfcjwR9tAyZqhtyaMN991lF/ZfHfr5tzZQ8c7y7aBgZbjfbd0fjFwQ==",
+      "requires": {
+        "tweetnacl": "1.x.x"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+        }
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -6779,11 +7156,18 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
+    "ethereum-blockies-base64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ethereum-blockies-base64/-/ethereum-blockies-base64-1.0.2.tgz",
+      "integrity": "sha512-Vg2HTm7slcWNKaRhCUl/L3b4KrB8ohQXdd5Pu3OI897EcR6tVRvUqdTwAyx+dnmoDzj8e2bwBLDQ50ByFmcz6w==",
+      "requires": {
+        "pnglib": "0.0.1"
+      }
+    },
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "events": {
       "version": "3.3.0",
@@ -9346,6 +9730,14 @@
         "handlebars": "^4.0.3"
       }
     },
+    "jdenticon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/jdenticon/-/jdenticon-3.1.1.tgz",
+      "integrity": "sha512-/m0Kk5ou7tPHjW6YovCysRETqPlFcTabWG96r8NbbSsEK+eQ3jHiGULaGOtp4XBqkRxWS1XMopLRGwdhet5ezw==",
+      "requires": {
+        "canvas-renderer": "~2.2.0"
+      }
+    },
     "jest": {
       "version": "23.6.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-23.6.0.tgz",
@@ -10988,6 +11380,11 @@
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
     },
+    "micro-base": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/micro-base/-/micro-base-0.10.0.tgz",
+      "integrity": "sha512-huKVznyEDZVO7pcYoVZMBR6prkxzkJSTT96T2tyHY1Wk3Sywcpb7NwxHAwKf/fmfqsdFuY2rDRR3UYkY6Uh9LQ=="
+    },
     "micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
@@ -12028,6 +12425,11 @@
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
+    },
+    "pnglib": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pnglib/-/pnglib-0.0.1.tgz",
+      "integrity": "sha1-+atvnGiPSp1Xmti+KIeKcW4wwJY="
     },
     "pnp-webpack-plugin": {
       "version": "1.1.0",
@@ -16690,6 +17092,15 @@
         "prop-types": "^15.6.0"
       }
     },
+    "react-copy-to-clipboard": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.4.tgz",
+      "integrity": "sha512-IeVAiNVKjSPeGax/Gmkqfa/+PuMTBhutEvFUaMQLwE2tS0EXrAdgOpWDX26bWTXF3HrioorR7lr08NqeYUWQCQ==",
+      "requires": {
+        "copy-to-clipboard": "^3",
+        "prop-types": "^15.5.8"
+      }
+    },
     "react-dev-utils": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-6.1.1.tgz",
@@ -18991,7 +19402,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.3.1"
       },
@@ -18999,8 +19409,7 @@
         "is-arrayish": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-          "dev": true
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
         }
       }
     },
@@ -19408,6 +19817,11 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
+    },
+    "store": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/store/-/store-2.0.12.tgz",
+      "integrity": "sha1-jFNOKguDH3K3X8XxEZhXxE711ZM="
     },
     "stream-browserify": {
       "version": "2.0.2",
@@ -20285,6 +20699,11 @@
           }
         }
       }
+    },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
     },
     "toidentifier": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.12.1",
+    "@polkadot/react-identicon": "^0.87.6",
     "@react-three/drei": "^7.16.8",
     "@react-three/fiber": "^7.0.17",
     "@react-three/postprocessing": "^2.0.5",

--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,7 @@ class App extends React.Component {
               objectUrl={"/assets/canary.glb"}
               nodes={this.state.nodesData}
               onNodeSelected={this.onNodeSelected.bind(this)}
+              onNodeClick={(nodeId) => { console.log("boom!", nodeId)}}
               debug={true}
             />
           

--- a/src/index.js
+++ b/src/index.js
@@ -36,11 +36,6 @@ class App extends React.Component {
     };
   }
 
-  onNodeSelected(node) {
-    this.setState({nodeSelected: node});
-    console.log("Node Selected:", this.state.nodeSelected);
-  }
-
   render() {
 
     return (
@@ -57,9 +52,7 @@ class App extends React.Component {
             <ThreeCanary
               objectUrl={"/assets/canary.glb"}
               nodes={this.state.nodesData}
-              onNodeSelected={this.onNodeSelected.bind(this)}
               onNodeClick={(nodeId) => { console.log("onNodeClick", nodeId)}}
-              debug={true}
             />
           
             <div

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ class App extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      nodesData: nodesDataFactory(1500),
+      nodesData: nodesDataFactory(150),
       nodeSelected: null
     };
   }
@@ -58,7 +58,7 @@ class App extends React.Component {
               objectUrl={"/assets/canary.glb"}
               nodes={this.state.nodesData}
               onNodeSelected={this.onNodeSelected.bind(this)}
-              onNodeClick={(nodeId) => { console.log("boom!", nodeId)}}
+              onNodeClick={(nodeId) => { console.log("onNodeClick", nodeId)}}
               debug={true}
             />
           

--- a/src/lib/ThreeCanary.js
+++ b/src/lib/ThreeCanary.js
@@ -25,7 +25,7 @@ const randomN = (min, max, n) => {
 }
 
 const cutText = (str) => {
-  const numChars = 7
+  const numChars = 6
   const sep = "..."
   const strLen = str.length
   const head = str.slice(0, numChars)

--- a/src/lib/ThreeCanary.js
+++ b/src/lib/ThreeCanary.js
@@ -33,13 +33,18 @@ const cutText = (str) => {
   return head + sep + tail
 }
 
-function Points({ objectUrl, nodesData, onNodeClick, randomIndexes }) {
+function Points({ objectUrl, nodesData, onNodeClick }) {
   // Note: useGLTF caches it already
   const { nodes } = useGLTF(objectUrl)
   const [selected, setSelected] = useState(0)
 
   // Or nodes.Scene.children[0].geometry.attributes.position
   const positions = nodes.canary.geometry.attributes.position
+  
+  const numPositions = positions.count
+  const numNodes = nodesData.length
+  const randomIndexes = useMemo(() => randomN(0, numPositions, numNodes), [])
+
   const selectedPositions = randomIndexes.map((i) => [positions.getX(i), positions.getY(i), positions.getZ(i)])
 
   const handleSelectedNode = (nodeId) => {
@@ -95,7 +100,7 @@ function Point({ nodeId, position, onNodeSelected }) {
         <Instance
           ref={ref}
           /* eslint-disable-next-line */
-          onPointerOver={(e) => (e.stopPropagation(), setHover(true))}
+          onPointerOver={(e) => (e.stopPropagation(), setHover(true),  onNodeSelected(nodeId))}
           onPointerOut={() => setHover(false)}
           onClick={(e) => onNodeSelected(nodeId)}
           />
@@ -241,10 +246,6 @@ function Particles({ count }) {
 function ThreeCanary(props) {
   const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
 
-  const numPositions = 3471 // positions.count
-  const numNodes = props.nodes.length
-  const randomIndexes = randomN(0, numPositions, numNodes)
-
   return (
     <Canvas shadows dpr={[1, 2]} camera={{ position: [2.3, 1, 1], fov: 50 }} performance={{ min: 0.1 }}>
       
@@ -254,7 +255,7 @@ function ThreeCanary(props) {
 
       <Suspense fallback={null}>
         <Model scale={0.1} objectUrl={props.objectUrl} />
-        <Points randomIndexes={randomIndexes} objectUrl={props.objectUrl} nodesData={props.nodes} onNodeClick={props.onNodeClick} />
+        <Points objectUrl={props.objectUrl} nodesData={props.nodes} onNodeClick={props.onNodeClick} />
         <Particles count={isMobile ? 50 : 200} />
 
         <EffectComposer multisampling={16}>
@@ -285,7 +286,7 @@ const DialogContent = styled.div`
   animation-fill-mode: forwards;
 
   padding-top: 10px;
-  transform: translate3d(50%, 0, 0);
+  transform: translate3d(10px, 10px, 0);
 
   text-align: left;
   background: ${brandPalette[1]};

--- a/src/lib/ThreeCanary.js
+++ b/src/lib/ThreeCanary.js
@@ -285,9 +285,6 @@ const DialogContent = styled.div`
   animation-iteration-count: 1;
   animation-fill-mode: forwards;
 
-  padding-top: 10px;
-  transform: translate3d(10px, 10px, 0);
-
   text-align: left;
   background: ${brandPalette[1]};
 

--- a/src/lib/ThreeCanary.js
+++ b/src/lib/ThreeCanary.js
@@ -1,4 +1,5 @@
-import * as THREE from "three";
+import * as THREE from "three"
+import Identicon from '@polkadot/react-identicon'
 import React, { useMemo, useRef, useState, Suspense, useLayoutEffect } from 'react'
 import styled, { keyframes } from 'styled-components'
 import { Canvas, useFrame } from '@react-three/fiber'
@@ -24,7 +25,8 @@ const randomN = (min, max, n) => {
   return numbers;
 }
 
-const cutText = (str) => {
+const formatHash = (str) => {
+  if (!str) return ""
   const numChars = 6
   const sep = "..."
   const strLen = str.length
@@ -43,7 +45,7 @@ function Points({ objectUrl, nodesData, onNodeClick }) {
   
   const numPositions = positions.count
   const numNodes = nodesData.length
-  const randomIndexes = useMemo(() => randomN(0, numPositions, numNodes), [])
+  const randomIndexes = useMemo(() => randomN(0, numPositions, numNodes), [numPositions, numNodes])
 
   const selectedPositions = randomIndexes.map((i) => [positions.getX(i), positions.getY(i), positions.getZ(i)])
 
@@ -131,10 +133,33 @@ function PointDialog({ position, dialogData, onNodeClick }) {
         <meshStandardMaterial roughness={0.75} metalness={0.8} emissive={brandPalette[0]} />
         <Html distanceFactor={2}>
           <DialogContent>
-            { dialogData.img ? <DialogImage src={ dialogData.img } alt={ dialogData.name } onClick={handleNodeClick} /> : null } 
-            { dialogData.name ? <DialogTitle onClick={handleNodeClick}>{ dialogData.name }</DialogTitle> : null }
-            { dialogData.level ? <DialogLabel>{ dialogData.level }</DialogLabel> : null }
-            { dialogData.hash ? <DialogHash>{ cutText(dialogData.hash) }</DialogHash> : null }
+            { dialogData.hash && !dialogData.img ?
+                <div onClick={handleNodeClick}>
+                  <DialogIdenticon
+                    value={dialogData.hash}
+                    size={200}
+                    theme={'polkadot'}
+                  />
+                </div> : null}
+            { dialogData.img ?
+                <DialogImage
+                  src={ dialogData.img }
+                  alt={ dialogData.name }
+                  onClick={handleNodeClick}
+                /> : null } 
+            { dialogData.name ?
+                <DialogTitle
+                  onClick={handleNodeClick}>
+                  { dialogData.name }
+                </DialogTitle> : null }
+            { dialogData.level ?
+                <DialogLabel>
+                  { dialogData.level }
+                </DialogLabel> : null }
+            { dialogData.hash ?
+                <DialogHash>
+                  { formatHash(dialogData.hash) }
+                </DialogHash> : null }
           </DialogContent>
         </Html>
       </mesh>
@@ -298,6 +323,12 @@ const DialogContent = styled.div`
 const DialogImage = styled.img`
   width: 200px;
 
+  &:hover {
+    cursor: pointer;
+  }
+`
+
+const DialogIdenticon = styled(Identicon)`
   &:hover {
     cursor: pointer;
   }


### PR DESCRIPTION
In preparation for adding an offcanvas component into https://github.com/KappaSigmaMu/ksm-app:
- [x] Expose the `onNodeClick` handler that is triggered when either image or title of current `PointDialog` content is clicked. The callback function provides the hash id of selected node
- [x] Move `PointDialog` to parent node, displaying only one dialog at a time
- [x] Match style to KSM style guides
- [x] Move event to hovering node instead only on node click
- [x] Add Polkadot's Identicon as an alternative for tattoo image


https://user-images.githubusercontent.com/49062/147029133-49a41499-129f-4b02-81c0-5b8dbedc1007.mp4

