### PR TITLE
Pin packages versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,24 @@
 {
   "name": "@kappasigmamu/canary-component",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kappasigmamu/canary-component",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "license": "MIT",
       "dependencies": {
-        "@babel/polyfill": "^7.12.1",
-        "@react-three/drei": "^8.11.1",
-        "@react-three/fiber": "^7.0.17",
-        "@react-three/postprocessing": "^2.0.5",
-        "@types/three": "^0.136.0",
+        "@babel/polyfill": "7.12.1",
+        "@react-three/drei": "8.11.1",
+        "@react-three/fiber": "7.0.26",
+        "@react-three/postprocessing": "2.1.6",
+        "@types/three": "0.136.0",
         "core-js": "^3.19.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "styled-components": "^5.3.0",
-        "three": "^0.136.0"
+        "three": "0.136.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.15.7",
@@ -2225,9 +2225,9 @@
       "dev": true
     },
     "node_modules/@types/three": {
-      "version": "0.136.1",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.136.1.tgz",
-      "integrity": "sha512-gzTw6RR4dU8sGf+RpLBWWKHRVIJ4gwKVQPk+IFCgha04Efg/itXYUalX6iBcYeSmaDu0qE5M7uTq0XLQpU4FAg=="
+      "version": "0.136.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.136.0.tgz",
+      "integrity": "sha512-yNBe5U3B+eSZU+pmiDxeq3hDyF+ftYghFkY3y0ayZrF8SjoUMVIRXqEfJX39wTSDsiY4/+tkmKgNxhhIKbnxeQ=="
     },
     "node_modules/@use-gesture/core": {
       "version": "10.2.6",
@@ -23938,9 +23938,9 @@
       "dev": true
     },
     "@types/three": {
-      "version": "0.136.1",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.136.1.tgz",
-      "integrity": "sha512-gzTw6RR4dU8sGf+RpLBWWKHRVIJ4gwKVQPk+IFCgha04Efg/itXYUalX6iBcYeSmaDu0qE5M7uTq0XLQpU4FAg=="
+      "version": "0.136.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.136.0.tgz",
+      "integrity": "sha512-yNBe5U3B+eSZU+pmiDxeq3hDyF+ftYghFkY3y0ayZrF8SjoUMVIRXqEfJX39wTSDsiY4/+tkmKgNxhhIKbnxeQ=="
     },
     "@use-gesture/core": {
       "version": "10.2.6",

--- a/package.json
+++ b/package.json
@@ -21,16 +21,16 @@
     "url": "git+https://github.com/KappaSigmaMu/canary-component.git"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.12.1",
-    "@react-three/drei": "^8.11.1",
-    "@react-three/fiber": "^7.0.17",
-    "@react-three/postprocessing": "^2.0.5",
-    "@types/three": "^0.136.0",
+    "@babel/polyfill": "7.12.1",
+    "@react-three/drei": "8.11.1",
+    "@react-three/fiber": "7.0.26",
+    "@react-three/postprocessing": "2.1.6",
+    "@types/three": "0.136.0",
     "core-js": "^3.19.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "styled-components": "^5.3.0",
-    "three": "^0.136.0"
+    "three": "0.136.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.15.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kappasigmamu/canary-component",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "React Component that renders the KappaSigmaMu Canary in 3D",
   "keywords": [
     "kusama",


### PR DESCRIPTION
Recently, after some of our dependencies got new versions, the build started intermittently failing. I believe the reason is because we are using carets on our packages versions, this allows for a lot of different possibilities when building. For now, I'm fixing the versions based on our last stable lock, just to prevent the build from failing. Later we can update the packages and resolve the breaking changes they introduce.